### PR TITLE
feat: add cache settings

### DIFF
--- a/routes/blocks.js
+++ b/routes/blocks.js
@@ -34,6 +34,7 @@ function fromHexString(hexString) {
 }
 
 router.get("/:height_or_hash", async function (req, res) {
+  res.setHeader("Cache-Control", "public, max-age=120, immutable");
   try {
     let client = createClient();
     let height_or_hash = req.params.height_or_hash;

--- a/routes/mempool.js
+++ b/routes/mempool.js
@@ -7,6 +7,7 @@ var router = express.Router();
 
 /* GET mempool page. */
 router.get("/:excessSigs", async function (req, res) {
+  res.setHeader("Cache-Control", "public, max-age=0, must-revalidate");
   try {
     let client = createClient();
     let txId = req.params.excessSigs.split("+");

--- a/routes/search_commitments.js
+++ b/routes/search_commitments.js
@@ -26,6 +26,7 @@ var express = require("express");
 var router = express.Router();
 
 router.get("/", async function (req, res) {
+  res.setHeader("Cache-Control", "public, max-age=120, immutable");
   let client = createClient();
   let commitments = (
     req.query.comm ||

--- a/routes/search_kernels.js
+++ b/routes/search_kernels.js
@@ -26,6 +26,7 @@ var express = require("express");
 var router = express.Router();
 
 router.get("/", async function (req, res) {
+  res.setHeader("Cache-Control", "public, max-age=120, immutable");
   let client = createClient();
   let nonces = (req.query.nonces || "").split(",");
   let signatures = (req.query.signatures || "").split(",");


### PR DESCRIPTION
Description
---
Add cache settings. 2 minutes on blocks, and other searches, 0 on mempool. We can discuss the cache length. Once we go live, we can cache the block after some time indefinitely (the ones that are never going to be reorg again).

Motivation and Context
---

How Has This Been Tested?
---
Running tari-explorer locally. 

What process can a PR reviewer use to test or verify this change?
---
Run locally to make sure that the response headers are properly set.

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
