### PR TITLE
fix: adds tip height to blocks cache for second request to listHeaders

### DIFF
--- a/routes/index.js
+++ b/routes/index.js
@@ -104,6 +104,7 @@ export async function getIndexData(from, limit) {
     // Get one more header than requested so we can work out the difference in MMR_size
     // TODO: Add cache headers properly here
     cache.get(client.listHeaders, {
+      tip_height: tipHeight,
       from_height: from,
       num_headers: limit + 1,
     }),


### PR DESCRIPTION
Description
Adds tip height to blocks cache for second request to listHeaders

Motivation and Context
Fix the behind block headers

How Has This Been Tested?
Ran locally and could not get any behind headers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved data retrieval consistency by ensuring the latest header information is always included when loading data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->