### PR TITLE
fix: attempt to fix docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,43 +1,26 @@
-# syntax = docker/dockerfile:1.3
+# https://hub.docker.com/_/node
+ARG NODE_VERSION=22-bookworm-slim
 
-FROM node:22-bookworm-slim AS builder
+FROM node:$NODE_VERSION
 
-# Arguments for the builder stage
 ARG EXTERNAL_LIBS_LOCATION=./external_libs
+ARG BASE_NODE_PROTO=../proto/base_node.proto
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends dumb-init
+
 WORKDIR /usr/src/app
-COPY package*.json ./
-RUN npm ci
+COPY --chown=node:node . .
+
 RUN npm install ${EXTERNAL_LIBS_LOCATION}/base_node_grpc_client/
-COPY . .
+RUN npm install
+# Hack - bring proto files in
 RUN cp -fvr ${EXTERNAL_LIBS_LOCATION}/base_node_grpc_client/proto applications/minotari_app_grpc/proto
 RUN npm run build
 
-
-# --- Production ---
-FROM node:22-bookworm-slim
-
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends dumb-init && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
-
-# Set production environment
 ENV NODE_ENV=production
-
-WORKDIR /usr/src/app
-
-# Copy package.json and install ONLY production dependencies
-COPY --from=builder /usr/src/app/package*.json ./
-RUN npm ci --only=production
-
-# Copy the compiled code and other necessary assets from the builder stage
-COPY --from=builder --chown=node:node /usr/src/app/build ./build
-COPY --from=builder --chown=node:node /usr/src/app/applications ./applications
-
-ARG BASE_NODE_PROTO=../proto/base_node.proto
 ENV BASE_NODE_PROTO=${BASE_NODE_PROTO}
 
 EXPOSE 4000
-
 USER node
 CMD ["dumb-init", "node", "./build/index.js"]


### PR DESCRIPTION
This revets all docker changes and just sets node env to production after npm install
this is so devDeps are also included on build which are needed for `tsc` and `rimraf`