### PR TITLE
fix: pow chart data

### DIFF
--- a/routes/index.ts
+++ b/routes/index.ts
@@ -172,7 +172,7 @@ export async function getIndexData(from: number, limit: number) {
 
   for (let i = 0; i < last100Headers.length - 1; i++) {
     const algo = last100Headers[i]?.pow?.pow_algo;
-    const arr = algo === 0n ? sha3X : algo === 1n ? moneroRx : tariRx;
+    const arr = algo === 0n ? moneroRx : algo === 1n ? sha3X : tariRx;
     if (i < 10) {
       arr[0] += 1;
     }


### PR DESCRIPTION
Description
---
There was a small mistake in the logic to assign the proof of work values on the homepage.

It was:
```
sha3X = 0 | moneroRx = 1 | tariRx = 2
```

It should be:
```
moneroRx = 0 | sha3X = 1 | tariRx = 2
```

Motivation and Context
---
The values were being assigned incorrectly, causing errors on the POW chart

How Has This Been Tested?
---
Manually

What process can a PR reviewer use to test or verify this change?
---
Run the app and check if the data on the pow chart corresponds with the data in the latest blocks table.

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---
x

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
