### PR TITLE
fix: serialise Buffer as hex string

### DIFF
--- a/app.ts
+++ b/app.ts
@@ -198,6 +198,13 @@ export const app = express();
 const updater = new BackgrounUpdater();
 updater.start();
 
+app.set('json replacer', function (key, value) {
+  if (value && typeof value === 'object' && 'type' in value && value.type === 'Buffer') {
+    return Buffer.from(value.data).toString("hex");
+  }
+  return value;
+})
+
 // view engine setup
 app.set("views", path.join(__dirname, "../views"));
 app.set("view engine", "hbs");

--- a/cache.ts
+++ b/cache.ts
@@ -1,6 +1,4 @@
 import { handleGrpcResult } from "./utils/grpcHelpers.js";
-import JSONbig from "json-bigint";
-JSONbig({ useNativeBigInt: true });
 
 class Cache<T> {
   limit: number;

--- a/index.ts
+++ b/index.ts
@@ -7,9 +7,16 @@
 import { app } from "./app.js";
 import debugLib from "debug";
 import http from "http";
-import JSONbig from "json-bigint";
-const JSONbigFunc = JSONbig({ useNativeBigInt: true });
-global.JSON = JSONbigFunc as any;
+
+declare global {
+  interface BigInt {
+    toJSON(): string;
+  }
+}
+
+BigInt.prototype.toJSON = function () {
+  return this.toString();
+};
 
 const debug = debugLib("tari-explorer:server");
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,6 @@
         "fast-csv": "^5.0.2",
         "grpc-promise": "^1.4.0",
         "hbs": "^4.1.2",
-        "json-bigint": "^1.0.0",
         "long": "^5.3.2",
         "nice-grpc": "^2.1.12",
         "pino-http": "^10.5.0",
@@ -1469,14 +1468,6 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
-    },
-    "node_modules/bignumber.js": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.0.tgz",
-      "integrity": "sha512-EM7aMFTXbptt/wZdMlBv2t8IViwQL+h6SLHosp8Yf0dqJMTnY6iL32opnAB6kAdL0SZPuvcAzFr31o0c/R3/RA==",
-      "engines": {
-        "node": "*"
-      }
     },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
@@ -3272,14 +3263,6 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
-      }
-    },
-    "node_modules/json-bigint": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
-      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
-      "dependencies": {
-        "bignumber.js": "^9.0.0"
       }
     },
     "node_modules/json-buffer": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "fast-csv": "^5.0.2",
     "grpc-promise": "^1.4.0",
     "hbs": "^4.1.2",
-    "json-bigint": "^1.0.0",
     "long": "^5.3.2",
     "nice-grpc": "^2.1.12",
     "pino-http": "^10.5.0",


### PR DESCRIPTION
This pull request introduces new endpoints for block information and improves serialisation of byte Buffer.

**BigInt and JSON Handling Improvements:**

* Removed the `json-bigint` dependency and its usage throughout the codebase, simplifying JSON serialization logic. [[1]](diffhunk://#diff-4f6cea32cbd9fdd135cf897030d53736239a1219915ab161bce0c016322d1335L2-L3) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L30) [[3]](diffhunk://#diff-dcdc3e0b3362edb8fec2a51d3fa51f8fb8af8f70247e06d9887fa934834c9122L10-R19)
* Added a global `toJSON` method to the `BigInt` prototype, ensuring that `bigint` values are serialized as strings in JSON outputs.
* Configured Express with a custom JSON replacer to convert Buffer objects to hexadecimal strings during JSON serialization.

**New API Endpoints for Block Data:**

* Added `/tip/height` endpoint to retrieve the current tip block height, using cache when available and falling back to a live query if necessary.
* Added `/:height/header` endpoint to fetch block header information for a specific height, including the block hash and height.