### PR TITLE
feat: new endpoints for block headers

### DIFF
--- a/routes/blocks.ts
+++ b/routes/blocks.ts
@@ -253,7 +253,6 @@ router.get("/tip/height", async function (req: Request, res: Response) {
   if (res.locals.backgroundUpdater.isHealthy({ from, limit })) {
     // load the default page from cache
     tipHeight = res.locals.backgroundUpdater.getData().indexData.tipInfo.metadata.best_block_height;
-    console.log(`Tip height from cache: ${tipHeight}`);
   } else {
     const client = createClient();
     const tipInfo = await client.getTipInfo({});


### PR DESCRIPTION
This pull request adds two new endpoints to the `routes/blocks.ts` file, providing additional block-related data via the API. The main changes are the introduction of routes for retrieving the tip block height and fetching a block header by height.

**New API endpoints:**

* Added `GET /tip/height` endpoint to return the current tip block height, using cached data when available for improved performance.
* Added `GET /:height/header` endpoint to fetch the header information (height and hash) for a block at a specific height.